### PR TITLE
Test that the MIMIC-IV ETL runs on the MIMIC-IV demo dataset

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,6 +25,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
+    - name: Install MEDS ETL
+      run: python -m pip install .
     - name: Download MIMIC-IV-Demo (v2.2)
       run: |
         # Download the MIMIC-IV-Demo dataset (v2.2) to a tests/data/ directory

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,6 +25,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
+    - name: Download MIMIC-IV-Demo (v2.2)
+      run: |
+        # Download the MIMIC-IV-Demo dataset (v2.2) to a tests/data/ directory
+        wget -r -N -c --no-host-directories --cut-dirs=1 -np -P tests/data https://physionet.org/files/mimic-iv-demo/2.2/
     - name: Run tests
       run: |
-        pytest
+        pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Test data
+tests/data/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # meds_etl
+
 A collection of ETLs from common data formats to Medical Event Data Standard (MEDS)
 
 This package library currently supports:
@@ -17,3 +18,20 @@ In order to run the MIMIC-IV ETL, simply run the following command:
 In order to run the MIMIC-IV ETL, simply run the following command:
 
 `meds_etl_omop omop omop-esds` where omop is a folder containing csv files (optionally gzipped) for an OMOP dataset. Each table should either be a csv file with the table name (such as person.csv) or a folder with the table name containing csv files.
+
+## Unit tests
+
+Tests can be run from the project root with the following command:
+
+```
+pytest -v
+```
+
+Tests requiring data will be skipped unless the `tests/data/` folder is populated first. 
+
+To download the testing data, run the following command/s from project root:
+
+```
+# Download the MIMIC-IV-Demo dataset (v2.2) to a tests/data/ directory
+wget -r -N -c --no-host-directories --cut-dirs=1 -np -P tests/data https://physionet.org/files/mimic-iv-demo/2.2/
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "polars >= 0.19",
     "jsonschema >= 4.0.0",
     "meds >= 0.1",
+    "typing_extensions >= 4.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "jsonschema >= 4.0.0",
     "meds >= 0.1",
     "typing_extensions >= 4.0",
+    "datasets >= 2.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "esds",
     "polars >= 0.19",
     "jsonschema >= 4.0.0",
-    "meds >= 0.1",
+    "meds >= 0.1.1",
     "typing_extensions >= 4.0",
     "datasets >= 2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyarrow >= 12",
     "esds",
     "polars >= 0.19",
+    "jsonschema >= 4.0.0"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "pyarrow >= 12",
     "esds",
     "polars >= 0.19",
-    "jsonschema >= 4.0.0"
+    "jsonschema >= 4.0.0",
+    "meds >= 0.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
As discussed in https://github.com/Medical-Event-Data-Standard/meds_etl/issues/1, we would like to add some tests to confirm that the MIMIC ETL runs as expected.

This pull request:

- Adds a step to the Github workflow that wgets the [MIMIC-IV demo dataset](https://doi.org/10.13026/dp1f-ex47) from PhysioNet and puts it at: `tests/data/mimic-iv-demo`
- Adds instructions for downloading the MIMIC-IV demo dataset to `tests/data/mimic-iv-demo` locally
- If the dataset exists when pytest is run, checks that the `meds_etl_mimic` script successfully outputs files to a temporary destination folder at `tests/data/mimic-iv-demo/build/`