### PR TITLE
Update partition_by argument to fix deprecation warning. Closes #10.

### DIFF
--- a/src/meds_etl/flat.py
+++ b/src/meds_etl/flat.py
@@ -238,7 +238,7 @@ def create_and_write_shards_from_table(
             shard=patient_id.hash(213345) % num_shards,
         )
         .collect()
-        .partition_by("shard", as_dict=True, maintain_order=False)
+        .partition_by(["shard"], as_dict=True, maintain_order=False)
     )
 
     for shard_index, shard in event_data.items():


### PR DESCRIPTION
As discussed in #10, tests are currently failing for Polars >0.19. See for example: https://github.com/Medical-Event-Data-Standard/meds_etl/actions/runs/7673982626/job/20917734572. The problem is our use of deprecated `partition_by` syntax:

```
tests/test_flat.py::test_shuffle
  /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/meds_etl/flat.py:230: DeprecationWarning: `partition_by(..., as_dict=True)` will change to always return tuples as dictionary keys. Pass `by` as a list to silence this warning, e.g. `partition_by(['shard'], as_dict=True)`.
    table.select(
```

This pull request fixes the `partition_by` argument.

We might want to work out a way of pinning versions for development (e.g. a requirements file?).