### PR TITLE
Rewrite the MIMIC ETL to use the MEDS Flat intermediate

### DIFF
--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -41,7 +41,7 @@ class TestMimicETL:
             shutil.rmtree(cls.destination_path)
 
         # Run the ETL
-        subprocess.run(["meds_etl_mimic", cls.source_path, cls.destination_path, "--num_shards", "10"], check=True)
+        subprocess.run(["meds_etl_mimic", cls.source_path, cls.destination_path], check=True)
 
         # Initialize the dataset variable. Set it in the test_load_dataset method
         cls.dataset = None


### PR DESCRIPTION
This PR rewrites the MIMIC ETL to use the MEDS Flat intermediate step / ETL.

This has two advantages:

- It simplifies the MIMIC ETL, eliminating duplicative code

- It allows us to fix bugs once, in the Flat ETL, rather than fixing them multiple times

For example, this automatically closes #8 