### PR TITLE
Add optional native backend to meds_etl

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
     - name: Install MEDS ETL
-      run: python -m pip install ".[duckdb]"
+      run: python -m pip install ".[duckdb,cpp]"
     - name: Download MIMIC-IV-Demo (v2.2)
       run: |
         # Download the MIMIC-IV-Demo dataset (v2.2) to a tests/data/ directory

--- a/README.md
+++ b/README.md
@@ -15,7 +15,29 @@ conda create -n meds_etl
 ```
 Install the package
 ```bash
-python -m pip install .
+pip install meds_etl
+```
+
+## Backends
+
+ETLs are one of the most computationally heavy components of MEDS, so efficiency is very important.
+
+MEDS-ETL has several parallel implementations of core algorithms to balance the tradeoff between efficiency and ease of use.
+
+All commands generally take an additional parameter --backend, that allows users to switch between different backends.
+
+We currently support two backends polars (the default), and cpp.
+
+Backend information:
+
+- polars (default backend): A Python only implementation that only requires polars to run. The main issue with this implementation is that it is rather inefficient.
+
+- cpp: A custom C++ backend that requires the "meds_etl_cpp" package. Very efficient, but might not run on all platforms and has a limited feature set.
+
+If you want to use the native backend, make sure to install meds_etl with the optional native dependency.
+
+```bash
+pip install "meds_etl[cpp]"
 ```
 
 ## MIMIC-IV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
 duckdb = [
     "duckdb >= 0.10.1"
 ]
+cpp = [
+    "meds_etl_cpp == 0.1.2"
+]
+
 
 [project.scripts]
 meds_etl_mimic = "meds_etl.mimic:main"

--- a/src/meds_etl/mimic/__init__.py
+++ b/src/meds_etl/mimic/__init__.py
@@ -392,7 +392,7 @@ def main():
                     "code": code,
                 }
 
-                d, n, t = meds_etl.flat.convert_generic_value_to_specific(value, MIMIC_TIME_FORMATS)
+                d, n, t = meds_etl.flat.convert_generic_value_to_specific(value)
 
                 columns["datetime_value"] = d
                 columns["numeric_value"] = n

--- a/src/meds_etl/omop.py
+++ b/src/meds_etl/omop.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import argparse
+import itertools
 import json
 import multiprocessing
 import os
@@ -8,7 +11,7 @@ import shutil
 import subprocess
 import tempfile
 import uuid
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
 import jsonschema
 import meds
@@ -25,18 +28,33 @@ DEFAULT_VISIT_CONCEPT_ID: int = 8
 DEFAULT_NOTE_CONCEPT_ID: int = 46235038
 DEFAULT_VISIT_DETAIL_CONCEPT_ID: int = 4203722
 
+OMOP_TIME_FORMATS: Iterable[str] = ("%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%d")
 
-def get_table_files(path_to_src_omop_dir: str, table_name: str, table_details={}) -> List[str]:
-    """Retrieve all .csv/.csv.gz files for the OMOP table given by `table_name` in `path_to_src_omop_dir`
+
+def split_list(ls: List[Any], parts: int) -> List[List[Any]]:
+    per_list = (len(ls) + parts - 1) // parts
+    result = []
+
+    for i in range(parts):
+        sublist = ls[i * per_list : (i + 1) * per_list]
+        if len(sublist) > 0:
+            result.append(sublist)
+
+    return result
+
+
+def get_table_files(path_to_src_omop_dir: str, table_name: str, table_details={}) -> Tuple[List[str], List[str]]:
+    """Retrieve all .csv/.csv.gz/.parquet files for the OMOP table given by `table_name` in `path_to_src_omop_dir`
 
     Because OMOP tables can be quite large for datasets comprising millions
     of patients, those tables are often split into compressed shards. So
     the `measurements` "table" might actually be a folder containing files
     `000000000000.csv.gz` up to `000000000152.csv.gz`. This function
     takes a path corresponding to an OMOP table with its standard name (e.g.,
-    `condition_occurrence`, `measurement`, `observation`) and returns a list
-    of paths, each of which represents a file e.g.,
-    [`measurement/000000000000.csv.gz`, `000000000001.csv.gz`, ..., `000000000152.csv.gz`]
+    `condition_occurrence`, `measurement`, `observation`) and returns two list
+    of paths.
+
+    The first list contains all the csv files. The second list contains all parquet files.
     """
     if table_details.get("file_suffix"):
         table_name += "_" + table_details["file_suffix"]
@@ -44,17 +62,35 @@ def get_table_files(path_to_src_omop_dir: str, table_name: str, table_details={}
     path_to_table: str = os.path.join(path_to_src_omop_dir, table_name)
 
     if os.path.exists(path_to_table) and os.path.isdir(path_to_table):
-        return [
-            os.path.join(path_to_table, a)
-            for a in os.listdir(path_to_table)
-            if a.endswith(".csv") or a.endswith(".csv.gz")
-        ]
+        csv_files = []
+        parquet_files = []
+
+        for a in os.listdir(path_to_table):
+            fname = os.path.join(path_to_table, a)
+            if a.endswith(".csv") or a.endswith(".csv.gz"):
+                csv_files.append(fname)
+            elif a.endswith(".parquet"):
+                parquet_files.append(fname)
+
+        return csv_files, parquet_files
     elif os.path.exists(path_to_table + ".csv"):
-        return [path_to_table + ".csv"]
+        return [path_to_table + ".csv"], []
     elif os.path.exists(path_to_table + ".csv.gz"):
-        return [path_to_table + ".csv.gz"]
+        return [path_to_table + ".csv.gz"], []
+    elif os.path.exists(path_to_table + ".parquet"):
+        return [], [path_to_table + ".parquet"]
     else:
-        return []
+        return [], []
+
+
+def read_polars_df(fname: str) -> pl.DataFrame:
+    """Read a file that might be a CSV or Parquet file"""
+    if fname.endswith(".csv"):
+        return pl.read_csv(fname)
+    elif fname.endswith(".parquet"):
+        return pl.read_parquet(fname)
+    else:
+        raise RuntimeError("Found file of unknown type " + fname + " expected parquet or csv")
 
 
 def load_file(path_to_decompressed_dir: str, fname: str) -> Any:
@@ -76,7 +112,215 @@ def load_file(path_to_decompressed_dir: str, fname: str) -> Any:
         return open(fname)
 
 
-def process_table(args):
+def cast_to_datetime(table: pl.LazyFrame, column: str, move_to_end_of_day: bool = False):
+    if table.schema[column] == pl.Utf8():
+        if not move_to_end_of_day:
+            return (meds_etl.flat.parse_time(pl.col(column), OMOP_TIME_FORMATS),)
+        else:
+            # Try to cast time to a datetime but if only the date is available, then use
+            # that date with a timestamp of 23:59:59
+            time = pl.col(column)
+            time = pl.coalesce(
+                time.str.to_datetime("%Y-%m-%d %H:%M:%S%.f", strict=False, time_unit="us"),
+                time.str.to_datetime("%Y-%m-%d", strict=False, time_unit="us").dt.offset_by("1d").dt.offset_by("-1s"),
+            )
+            return time
+    elif table.schema[column] == pl.Date():
+        time = pl.col(column).cast(pl.Datetime(time_unit="us"))
+        if move_to_end_of_day:
+            time = time.dt.offset_by("1d").dt.offset_by("-1s")
+        return time
+    elif isinstance(table.schema[column], pl.Datetime):
+        return pl.col(column).cast(pl.Datetime(time_unit="us"))
+    else:
+        raise RuntimeError("Unknown how to handle date type? " + table.schema[column] + " " + column)
+
+
+def write_event_data(
+    path_to_MEDS_flat_dir: str,
+    get_batch: Any,
+    table_name: str,
+    all_table_details: Iterable[Mapping[str, Any]],
+    concept_id_map: Mapping[int, str],
+    concept_name_map: Mapping[int, str],
+) -> pl.LazyFrame:
+    """Write event data from the given table to event files in MEDS Flat format"""
+    for table_details in all_table_details:
+        batch = get_batch()
+        batch = batch.rename({c: c.lower() for c in batch.columns})
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+        # Determine what to use for the `patient_id` column in MEDS Flat  #
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+        # Define the MEDS Flat `patient_id` (left) to be the `person_id` columns in OMOP (right)
+        patient_id = pl.col("person_id").cast(pl.Int64)
+
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+        # Determine what to use for the `time` column in MEDS Flat  #
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+        # Use special processing for the `PERSON` OMOP table
+        if table_name == "person":
+            # Take the `birth_datetime` if its available, otherwise
+            # construct it from `year_of_birth`, `month_of_birth`, `day_of_birth`
+            time = pl.coalesce(
+                cast_to_datetime(batch, "birth_datetime"),
+                pl.datetime(
+                    pl.col("year_of_birth"),
+                    pl.coalesce(pl.col("month_of_birth"), 1),
+                    pl.coalesce(pl.col("day_of_birth"), 1),
+                    time_unit="us",
+                ),
+            )
+        else:
+            # Use the OMOP table name + `_start_datetime` as the `time` column
+            # if it's available otherwise `_start_date`, `_datetime`, `_date`
+            # in that order of preference
+            options = ["_start_datetime", "_start_date", "_datetime", "_date"]
+            options = [
+                cast_to_datetime(batch, table_name + option, move_to_end_of_day=True)
+                for option in options
+                if table_name + option in batch.columns
+            ]
+            assert len(options) > 0, f"Could not find the time column {batch.columns}"
+            time = pl.coalesce(options)
+
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+        # Determine what to use for the `code` column in MEDS Flat  #
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+        if table_details.get("force_concept_code"):
+            # Rather than getting the concept ID from the source table, we use the concept ID
+            # passed in by the user eg `4083587` for `Birth`
+            source_concept_id = pl.lit(0, dtype=pl.Int64)
+            code = pl.lit(table_details.get("force_concept_code"), dtype=pl.Utf8)
+        else:
+            # Try using the source concept ID, but if it's not available then use the concept ID
+            concept_id_field = table_details.get("concept_id_field", table_name + "_concept_id")
+            concept_id = pl.col(concept_id_field).cast(pl.Int64)
+            if concept_id_field.replace("_concept_id", "_source_concept_id") in batch.columns:
+                source_concept_id = pl.col(concept_id_field.replace("_concept_id", "_source_concept_id")).cast(pl.Int64)
+            else:
+                source_concept_id = pl.lit(0, dtype=pl.Int64)
+
+            # And if the source concept ID and concept ID aren't available, use `fallback_concept_id`
+            fallback_concept_id = pl.lit(table_details.get("fallback_concept_id", None), dtype=pl.Int64)
+
+            concept_id = (
+                pl.when(source_concept_id != 0)
+                .then(source_concept_id)
+                .when(concept_id != 0)
+                .then(concept_id)
+                .otherwise(fallback_concept_id)
+            )
+
+            # Replace values in `concept_id` with the normalized concepts to which they are mapped
+            # based on the `concept_id_map`
+            code = concept_id.replace(concept_id_map)
+
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+        # Determine what to use for the `value` column in MEDS Flat   #
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+        # By default, if the user doesn't specify in `table_details`
+        # what the
+        value = pl.lit(None, dtype=str)
+
+        if table_details.get("string_value_field"):
+            value = pl.col(table_details["string_value_field"])
+        if table_details.get("numeric_value_field"):
+            value = pl.coalesce(pl.col(table_details["numeric_value_field"]), value)
+
+        if table_details.get("concept_id_value_field"):
+            concept_id_value = pl.col(table_details["concept_id_value_field"]).cast(pl.Int64)
+
+            # Normally we would prefer string or numeric value.
+            # But sometimes we get a value_as_concept_id with no string or numeric value.
+            # So we want to define a backup value here
+            #
+            # There are two reasons for this, each with different desired behavior:
+            # 1. OMOP defines a code with a maps to value relationship.
+            #      See https://www.ohdsi.org/web/wiki/doku.php?id=documentation:vocabulary:mapping
+            #      In this cases we generally just want to drop the value, as the data is in source_concept_id
+            # 2. The ETL has decided to put non-maps to value codes in observation for various reasons.
+            #      For instance STARR-OMOP puts shc_medical_hx in here
+            #      In this case, we generally want to create a string value with the source code value.
+
+            backup_value = (
+                pl.when((source_concept_id == 0) & (concept_id_value != 0))
+                .then(
+                    # Source concept 0 indicates we need a backup value since it's not captured by the source
+                    "SOURCE_CODE/"
+                    + pl.col(concept_id_field.replace("_concept_id", "_source_value"))
+                )
+                .otherwise(
+                    # Should be captured by the source concept id, so just map the value to a string.
+                    concept_id_value.map_dict(concept_name_map)
+                )
+            )
+
+            value = pl.coalesce(value, backup_value)
+
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+        # Determine the metadata columns to be stored in MEDS Flat  #
+        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+        # Every key in the `metadata` dictionary will become a distinct
+        # column in the MEDS Flat file; for each event, the metadata column
+        # and its corresponding value for a given patient will be stored
+        # as event metadata in the MEDS representation
+        metadata = {
+            "table": pl.lit(table_name, dtype=str),
+        }
+
+        if "visit_occurrence_id" in batch.columns:
+            metadata["visit_id"] = pl.col("visit_occurrence_id")
+
+        if "unit_source_value" in batch.columns:
+            metadata["unit"] = pl.col("unit_source_value")
+
+        if "load_table_id" in batch.columns:
+            metadata["clarity_table"] = pl.col("load_table_id")
+
+        if "note_id" in batch.columns:
+            metadata["note_id"] = pl.col("note_id")
+
+        if (table_name + "_end_datetime") in batch.columns:
+            end = cast_to_datetime(batch, table_name + "_end_datetime", move_to_end_of_day=True)
+            metadata["end"] = end
+
+        batch = batch.filter(code.is_not_null())
+
+        columns = {
+            "patient_id": patient_id,
+            "time": time,
+            "code": code,
+        }
+
+        d, n, t = meds_etl.flat.convert_generic_value_to_specific(value)
+
+        columns["datetime_value"] = d
+        columns["numeric_value"] = n
+        columns["text_value"] = t
+
+        # Add metadata columns to the set of MEDS flat dataframe columns
+        for k, v in metadata.items():
+            columns[k] = v.alias(k)
+
+        # We don't worry about partitioning here; let `flat_to_meds` handle that
+        event_data = batch.select(**columns)
+        # Write this part of the MEDS Flat file to disk
+        fname = os.path.join(path_to_MEDS_flat_dir, f'{table_name.replace("/", "_")}_{uuid.uuid4()}.parquet')
+        try:
+            event_data.sink_parquet(fname, compression="zstd", compression_level=1, maintain_order=False)
+        except pl.exceptions.InvalidOperationError as e:
+            print(table_name)
+            print(e)
+            print(event_data.explain(streaming=True))
+            raise e
+
+
+def process_table_csv(args):
     (
         table_file,
         table_name,
@@ -85,7 +329,6 @@ def process_table(args):
         concept_name_map_data,
         path_to_MEDS_flat_dir,
         path_to_decompressed_dir,
-        map_index,
         verbose,
     ) = args
     """
@@ -131,187 +374,61 @@ def process_table(args):
 
             batch = batch[0]  # (Because `table.next_batches` returns a list)
 
-            batch = batch.lazy().rename({c: c.lower() for c in batch.columns})
+            batch = batch.lazy()
 
-            for i, table_details in enumerate(all_table_details):
-                if verbose:
-                    print(f"Batch {i}")
+            write_event_data(
+                path_to_MEDS_flat_dir,
+                lambda: batch.lazy(),
+                table_name,
+                all_table_details,
+                concept_id_map,
+                concept_name_map,
+            )
 
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-                # Determine what to use for the `patient_id` column in MEDS Flat  #
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-                # Define the MEDS Flat `patient_id` (left) to be the `person_id` columns in OMOP (right)
-                patient_id = pl.col("person_id").cast(pl.Int64)
+def process_table_parquet(args):
+    (
+        table_files,
+        table_name,
+        all_table_details,
+        concept_id_map_data,
+        concept_name_map_data,
+        path_to_MEDS_flat_dir,
+        verbose,
+    ) = args
+    """
 
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-                # Determine what to use for the `time` column in MEDS Flat  #
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    This function is designed to be called through parallel processing utilities
+    such as `pool.imap_unordered(process_table, [args1, args2, ..., argsN])
 
-                # Use special processing for the `PERSON` OMOP table
-                if table_name == "person":
-                    # Take the `birth_datetime` if its available, otherwise
-                    # construct it from `year_of_birth`, `month_of_birth`, `day_of_birth`
-                    time = pl.coalesce(
-                        pl.col("birth_datetime").str.to_datetime("%Y-%m-%d %H:%M:%S%.f", strict=False, time_unit="ms"),
-                        pl.datetime(
-                            pl.col("year_of_birth"),
-                            pl.coalesce(pl.col("month_of_birth"), 1),
-                            pl.coalesce(pl.col("day_of_birth"), 1),
-                        ),
-                    )
-                else:
-                    # Use the OMOP table name + `_start_datetime` as the `time` column
-                    # if it's available otherwise `_start_date`, `_datetime`, `_date`
-                    # in that order of preference
-                    options = ["_start_datetime", "_start_date", "_datetime", "_date"]
-                    options = [
-                        pl.col(table_name + option) for option in options if table_name + option in batch.columns
-                    ]
-                    assert len(options) > 0, f"Could not find the time column {batch.columns}"
-                    time = pl.coalesce(options)
+    Args:
+        args (tuple): A tuple with the following elements:
+            table_file (str): Path to the raw source table file (can be compressed)
+            table_name (str): Name of the source table. Used for table-specific preprocessing
+                and selecting columns which often have the table name embedded within them
+                such as `measurement_datetime` in the `measurement` table.
+            all_table_details (List[Dict[str, Any]]): A list of details about the particular
+                table being processed that help determine how to map from the raw OMOP data
+                to the MEDS standard.
 
-                    # Try to cast time to a datetime but if only the date is available, then use
-                    # that date with a timestamp of 23:59:59
-                    time = pl.coalesce(
-                        time.str.to_datetime("%Y-%m-%d %H:%M:%S%.f", strict=False, time_unit="ms"),
-                        time.str.to_datetime("%Y-%m-%d", strict=False, time_unit="ms")
-                        .dt.offset_by("1d")
-                        .dt.offset_by("-1s"),
-                    )
+    """
+    concept_id_map = pickle.loads(concept_id_map_data)  # 0.25 GB for STARR-OMOP
+    concept_name_map = pickle.loads(concept_name_map_data)  # 0.5GB for STARR-OMOP
+    if verbose:
+        print("Working on ", table_files, table_name, all_table_details)
 
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-                # Determine what to use for the `code` column in MEDS Flat  #
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    if not isinstance(all_table_details, list):
+        all_table_details = [all_table_details]
 
-                if table_details.get("force_concept_id"):
-                    # Rather than getting the concept ID from the source table, we use the concept ID
-                    # passed in by the user eg `4083587` for `Birth`
-                    concept_id = pl.lit(table_details["force_concept_id"], dtype=pl.Int64)
-                    source_concept_id = pl.lit(0, dtype=pl.Int64)
-                else:
-                    # Try using the source concept ID, but if it's not available then use the concept ID
-                    concept_id_field = table_details.get("concept_id_field", table_name + "_concept_id")
-                    concept_id = pl.col(concept_id_field).cast(pl.Int64)
-                    if concept_id_field.replace("_concept_id", "_source_concept_id") in batch.columns:
-                        source_concept_id = pl.col(concept_id_field.replace("_concept_id", "_source_concept_id")).cast(
-                            pl.Int64
-                        )
-                    else:
-                        source_concept_id = pl.lit(0, dtype=pl.Int64)
-
-                    # And if the source concept ID and concept ID aren't available, use `fallback_concept_id`
-                    fallback_concept_id = pl.lit(table_details.get("fallback_concept_id", None), dtype=pl.Int64)
-
-                    concept_id = (
-                        pl.when(source_concept_id != 0)
-                        .then(source_concept_id)
-                        .when(concept_id != 0)
-                        .then(concept_id)
-                        .otherwise(fallback_concept_id)
-                    )
-
-                # Replace values in `concept_id` with the normalized concepts to which they are mapped
-                # based on the `concept_id_map`
-                code = concept_id.map_dict(concept_id_map)
-
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-                # Determine what to use for the `value` column in MEDS Flat   #
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
-                # By default, if the user doesn't specify in `table_details`
-                # what the
-                value = pl.lit(None, dtype=str)
-
-                if table_details.get("string_value_field"):
-                    value = pl.col(table_details["string_value_field"])
-                if table_details.get("numeric_value_field"):
-                    value = pl.coalesce(pl.col(table_details["numeric_value_field"]), value)
-
-                if table_details.get("concept_id_value_field"):
-                    concept_id_value = pl.col(table_details["concept_id_value_field"]).cast(pl.Int64)
-
-                    # Normally we would prefer string or numeric value.
-                    # But sometimes we get a value_as_concept_id with no string or numeric value.
-                    # So we want to define a backup value here
-                    #
-                    # There are two reasons for this, each with different desired behavior:
-                    # 1. OMOP defines a code with a maps to value relationship.
-                    #      See https://www.ohdsi.org/web/wiki/doku.php?id=documentation:vocabulary:mapping
-                    #      In this cases we generally just want to drop the value, as the data is in source_concept_id
-                    # 2. The ETL has decided to put non-maps to value codes in observation for various reasons.
-                    #      For instance STARR-OMOP puts shc_medical_hx in here
-                    #      In this case, we generally want to create a string value with the source code value.
-
-                    backup_value = (
-                        pl.when((source_concept_id == 0) & (concept_id_value != 0))
-                        .then(
-                            # Source concept 0 indicates we need a backup value since it's not captured by the source
-                            "SOURCE_CODE/"
-                            + pl.col(concept_id_field.replace("_concept_id", "_source_value"))
-                        )
-                        .otherwise(
-                            # Should be captured by the source concept id, so just map the value to a string.
-                            concept_id_value.map_dict(concept_name_map)
-                        )
-                    )
-
-                    value = pl.coalesce(value, backup_value)
-
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-                # Determine the metadata columns to be stored in MEDS Flat  #
-                # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
-                # Every key in the `metadata` dictionary will become a distinct
-                # column in the MEDS Flat file; for each event, the metadata column
-                # and its corresponding value for a given patient will be stored
-                # as event metadata in the MEDS representation
-                metadata = {
-                    "table": pl.lit(table_name, dtype=str),
-                }
-
-                if "visit_occurrence_id" in batch.columns:
-                    metadata["visit_id"] = pl.col("visit_occurrence_id")
-
-                if "unit_source_value" in batch.columns:
-                    metadata["unit"] = pl.col("unit_source_value")
-
-                if "load_table_id" in batch.columns:
-                    metadata["clarity_table"] = pl.col("load_table_id")
-
-                if "note_id" in batch.columns:
-                    metadata["note_id"] = pl.col("note_id")
-
-                if (table_name + "_end_datetime") in batch.columns:
-                    end = pl.col(table_name + "_end_datetime")
-                    end = pl.coalesce(
-                        end.str.to_datetime("%Y-%m-%d %H:%M:%S%.f", strict=False, time_unit="ms"),
-                        end.str.to_datetime("%Y-%m-%d", strict=False, time_unit="ms")
-                        .dt.offset_by("1d")
-                        .dt.offset_by("-1s"),
-                    )
-                    metadata["end"] = end
-
-                batch = batch.filter(code.is_not_null())
-
-                columns = {
-                    "patient_id": patient_id,
-                    "time": time,
-                    "code": code,
-                    "value": value,
-                }
-
-                # Add metadata columns to the set of MEDS flat dataframe columns
-                for k, v in metadata.items():
-                    columns[k] = v.alias(k)
-
-                # We don't worry about partitioning here; let `flat_to_meds` handle that
-                event_data = batch.select(**columns).collect()
-
-                # Write this part of the MEDS Flat file to disk
-                postfix = str(uuid.uuid4())
-                fname = os.path.join(path_to_MEDS_flat_dir, f'{table_name.replace("/", "_")}_{postfix}.parquet')
-                event_data.write_parquet(fname)
+    # Load the source table, decompress if needed
+    write_event_data(
+        path_to_MEDS_flat_dir,
+        lambda: pl.scan_parquet(table_files),
+        table_name,
+        all_table_details,
+        concept_id_map,
+        concept_name_map,
+    )
 
 
 def extract_metadata(path_to_src_omop_dir: str, path_to_decompressed_dir: str, verbose: int = 0) -> Tuple:
@@ -324,14 +441,15 @@ def extract_metadata(path_to_src_omop_dir: str, path_to_decompressed_dir: str, v
     # and use it to generate metadata file as well as populate maps
     # from (concept ID -> concept code) and (concept ID -> concept name)
     print("Generating metadata from OMOP `concept` table")
-    for concept_file in tqdm(get_table_files(path_to_src_omop_dir, "concept")):
+    for concept_file in tqdm(itertools.chain(*get_table_files(path_to_src_omop_dir, "concept"))):
         # Note: Concept table is often split into gzipped shards by default
         if verbose:
             print(concept_file)
         with load_file(path_to_decompressed_dir, concept_file) as f:
             # Read the contents of the `concept` table shard
             # `load_file` will unzip the file into `path_to_decompressed_dir` if needed
-            concept: pl.DataFrame = pl.read_csv(f.name)
+            concept = read_polars_df(f.name)
+
             concept_id = pl.col("concept_id").cast(pl.Int64)
             code = pl.col("vocabulary_id") + "/" + pl.col("concept_code")
 
@@ -360,33 +478,12 @@ def extract_metadata(path_to_src_omop_dir: str, path_to_decompressed_dir: str, v
                     "parent_codes": [],
                 }
 
-    # Find and store the Concept ID's used for Birth and Death
-    omop_birth_concept_id = None
-    omop_death_concept_id = None
-    for concept_id, code in tqdm(concept_id_map.items(), desc="Finding birth and death codes"):
-        if code == meds.birth_code:
-            omop_birth_concept_id = concept_id
-        elif code == meds.death_code:
-            omop_death_concept_id = concept_id
-        if omop_birth_concept_id is not None and omop_death_concept_id is not None:
-            break
-
-    if omop_birth_concept_id is None or omop_death_concept_id is None:
-        raise ValueError(
-            "The provided OMOP dataset is missing either the birth or death concept. \n"
-            + "Look for SNOMED codes "
-            + meds.birth_code
-            + " and "
-            + meds.death_code
-            + " within concept.csv"
-        )
-
     # Include map from custom concepts to normalized (ie standard ontology)
     # parent concepts, where possible, in the code_metadata dictionary
-    for concept_relationship_file in get_table_files(path_to_src_omop_dir, "concept_relationship"):
+    for concept_relationship_file in itertools.chain(*get_table_files(path_to_src_omop_dir, "concept_relationship")):
         with load_file(path_to_decompressed_dir, concept_relationship_file) as f:
             # This table has `concept_id_1`, `concept_id_2`, `relationship_id` columns
-            concept_relationship = pl.read_csv(f.name)
+            concept_relationship = read_polars_df(f.name)
 
             concept_id_1 = pl.col("concept_id_1").cast(pl.Int64)
             concept_id_2 = pl.col("concept_id_2").cast(pl.Int64)
@@ -410,9 +507,9 @@ def extract_metadata(path_to_src_omop_dir: str, path_to_decompressed_dir: str, v
     # Extract dataset metadata e.g., the CDM source name and its release date
     datasets: List[str] = []
     dataset_versions: List[str] = []
-    for cdm_source_file in get_table_files(path_to_src_omop_dir, "cdm_source"):
+    for cdm_source_file in itertools.chain(*get_table_files(path_to_src_omop_dir, "cdm_source")):
         with load_file(path_to_decompressed_dir, cdm_source_file) as f:
-            cdm_source = pl.read_csv(f.name)
+            cdm_source = read_polars_df(f.name)
             cdm_source = cdm_source.rename({c: c.lower() for c in cdm_source.columns})
             cdm_source = cdm_source.to_dict(as_series=False)
 
@@ -421,7 +518,7 @@ def extract_metadata(path_to_src_omop_dir: str, path_to_decompressed_dir: str, v
 
     metadata = {
         "dataset_name": "|".join(datasets),  # eg 'Epic Clarity SHC|Epic Clarity LPCH'
-        "dataset_version": "|".join(dataset_versions),  # eg '2024-02-01|2024-02-01'
+        "dataset_version": "|".join(str(a) for a in dataset_versions),  # eg '2024-02-01|2024-02-01'
         "etl_name": "meds_etl.omop",
         "etl_version": meds_etl.__version__,
         "code_metadata": code_metadata,  # `code_metadata` could have >100k keys
@@ -434,7 +531,7 @@ def extract_metadata(path_to_src_omop_dir: str, path_to_decompressed_dir: str, v
 
     jsonschema.validate(instance=metadata, schema=meds.dataset_metadata)
 
-    return metadata, concept_id_map, concept_name_map, omop_birth_concept_id, omop_death_concept_id
+    return metadata, concept_id_map, concept_name_map
 
 
 def main():
@@ -458,6 +555,12 @@ def main():
         "performed on a shard-by-shard basis).",
     )
     parser.add_argument("--num_proc", type=int, default=1, help="Number of vCPUs to use for performing the MEDS ETL")
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="polars",
+        help="The backend to use when performing an ETL. See the README for a discussion on possible backends.",
+    )
     parser.add_argument("--verbose", type=int, default=0)
     parser.add_argument(
         "--continue_job",
@@ -465,12 +568,6 @@ def main():
         action="store_true",
         help="If set, the job continues from a previous run, starting after the "
         "conversion to MEDS Flat but before converting from MEDS Flat to MEDS.",
-    )
-    parser.add_argument(
-        "--backend",
-        type=str,
-        default="duckdb",
-        help="The backend to use for the ETL. See the MEDS-Flat ETL for details on the various backends available.",
     )
 
     args = parser.parse_args()
@@ -512,7 +609,7 @@ def main():
         # Generate metadata.json from OMOP concept table  #
         # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-        metadata, concept_id_map, concept_name_map, omop_birth_concept_id, omop_death_concept_id = extract_metadata(
+        metadata, concept_id_map, concept_name_map = extract_metadata(
             path_to_src_omop_dir=args.path_to_src_omop_dir,
             path_to_decompressed_dir=path_to_decompressed_dir,
             verbose=args.verbose,
@@ -530,13 +627,11 @@ def main():
         # Convert all "measurements" to MEDS Flat, write to disk  #
         # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-        # tables = retrieve_table_specifications(omop_birth_concept_id)
-
         tables: Dict[str, Any] = {
             # Each key is a `table_name`
             "person": [  # `table_name`s map to `table_details`
                 {
-                    "force_concept_id": omop_birth_concept_id,
+                    "force_concept_code": meds.birth_code,
                 },
                 {
                     "concept_id_field": "gender_concept_id",
@@ -556,7 +651,7 @@ def main():
                 "file_suffix": "occurrence",
             },
             "death": {
-                "force_concept_id": omop_death_concept_id,
+                "force_concept_code": meds.death_code,
             },
             "procedure": {
                 "file_suffix": "occurrence",
@@ -592,15 +687,16 @@ def main():
         # Each subprocess will read in a decompressed file and put all measurements for a given patient
         # into that patient's corresponding shard. This makes creating patient timelines downstream
         # (where timelines incorporate measurements from across different tables) much less RAM intensive.
-        all_tasks = []
+        all_csv_tasks = []
+        all_parquet_tasks = []
         for table_name, table_details in tables.items():
-            table_files = get_table_files(
+            csv_table_files, parquet_table_files = get_table_files(
                 path_to_src_omop_dir=args.path_to_src_omop_dir,
                 table_name=table_name,
                 table_details=table_details[0] if isinstance(table_details, list) else table_details,
             )
 
-            all_tasks.extend(
+            all_csv_tasks.extend(
                 (
                     table_file,
                     table_name,
@@ -609,27 +705,49 @@ def main():
                     concept_name_map_data,
                     path_to_MEDS_flat_dir,
                     path_to_decompressed_dir,
-                    map_index,
                     args.verbose,
                 )
-                for map_index, table_file in enumerate(table_files)
+                for table_file in csv_table_files
             )
+
+            all_parquet_tasks.extend(
+                (
+                    table_files,
+                    table_name,
+                    table_details,
+                    concept_id_map_data,
+                    concept_name_map_data,
+                    path_to_MEDS_flat_dir,
+                    args.verbose,
+                )
+                for table_files in split_list(parquet_table_files, args.num_shards)
+            )
+
         random.seed(RANDOM_SEED)
-        random.shuffle(all_tasks)
+        random.shuffle(all_csv_tasks)
+        random.shuffle(all_parquet_tasks)
 
         print("Decompressing OMOP tables, mapping to MEDS Flat format, writing to disk...")
         if args.num_proc > 1:
             with multiprocessing.get_context("spawn").Pool(args.num_proc) as pool:
                 # Wrap all tasks with tqdm for a progress bar
-                total_tasks = len(all_tasks)
-                with tqdm(total=total_tasks, desc="Mapping OMOP tables -> MEDS format") as pbar:
-                    for _ in pool.imap_unordered(process_table, all_tasks):
+                total_tasks = len(all_csv_tasks)
+                with tqdm(total=total_tasks, desc="Mapping CSV OMOP tables -> MEDS format") as pbar:
+                    for _ in pool.imap_unordered(process_table_csv, all_csv_tasks):
+                        pbar.update()
+
+                total_tasks = len(all_parquet_tasks)
+                with tqdm(total=total_tasks, desc="Mapping Parquet OMOP tables -> MEDS format") as pbar:
+                    for _ in pool.imap_unordered(process_table_parquet, all_parquet_tasks):
                         pbar.update()
 
         else:
             # Useful for debugging `process_table` without multiprocessing
-            for task in tqdm(all_tasks):
-                process_table(task)
+            for task in tqdm(all_csv_tasks):
+                process_table_csv(task)
+
+            for task in tqdm(all_parquet_tasks):
+                process_table_parquet(task)
 
         # TODO: Do we need to do this more often so as to reduce maximum disk storage?
         shutil.rmtree(path_to_decompressed_dir)


### PR DESCRIPTION
The current ETLs within meds_etl work, but they are quite slow.

This adds an optimized implementation, written in C++ as an optional path.

The optimized code is within https://github.com/Medical-Event-Data-Standard/meds_etl_cpp.

From my simple tests, the newer code is roughly 100x faster than the old polars implementation.