### PR TITLE
extract events from the discharged_concept_id field of the visit table

### DIFF
--- a/src/meds_etl/omop.py
+++ b/src/meds_etl/omop.py
@@ -668,7 +668,15 @@ def main():
             "drug_exposure": {
                 "concept_id_field": "drug_concept_id",
             },
-            "visit": {"fallback_concept_id": DEFAULT_VISIT_CONCEPT_ID, "file_suffix": "occurrence"},
+            "visit": [
+                {
+                    "fallback_concept_id": DEFAULT_VISIT_CONCEPT_ID,
+                    "file_suffix": "occurrence"
+                },
+                {
+                    "concept_id_field": "discharged_to_concept_id",
+                },
+            ],
             "condition": {
                 "file_suffix": "occurrence",
             },


### PR DESCRIPTION
We want to extract discharged_concept_id as a separate event from the visit table. This will be important for identifying hospital discharge events to use ACES. 