### PR TITLE
Add check if `column` not in `schema` for `cast_to_datetime`

### DIFF
--- a/src/meds_etl/omop.py
+++ b/src/meds_etl/omop.py
@@ -117,6 +117,8 @@ def load_file(path_to_decompressed_dir: str, fname: str) -> Any:
 
 
 def cast_to_datetime(schema: Any, column: str, move_to_end_of_day: bool = False):
+    if column not in schema.names():
+        return pl.lit(None, dtype=pl.Datetime(time_unit="us"))
     if schema[column] == pl.Utf8():
         if not move_to_end_of_day:
             return meds_etl.utils.parse_time(pl.col(column), OMOP_TIME_FORMATS)


### PR DESCRIPTION
Allows `cast_to_datetime` to play nicely with the `pl.coalesce` operations when a column doesn't exist 

For example, in Lines 176-183, the column `"birth_datetime"` doesn't exist in the Truven OMOP. Currently, this causes an Exception. Instead, the `cast_to_datetime` call should just return None's and be gracefully handled by the `pl.coalesce` it's called in.