### PR TITLE
Add omop version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of ETLs from common data formats to Medical Event Data Standard (ME
 This package library currently supports:
 
 - MIMIC-IV
-- OMOP v5.4
+- OMOP v5.4/5.3 (this fork)
 - MEDS Unsorted, an unsorted version of MEDS
 
 ## Setup

--- a/src/meds_etl/omop.py
+++ b/src/meds_etl/omop.py
@@ -594,7 +594,7 @@ def main():
         "conversion to MEDS Unsorted but before converting from MEDS Unsorted to MEDS.",
     )
     parser.add_argument("--force_refresh", action="store_true", help="If set, this will overwrite all previous MEDS data in the output dir.")
-
+    parser.add_argument("--omop_version", type=string, help="Switch between OMOP 5.3/5.4, default 5.4.")
     args = parser.parse_args()
 
     if not os.path.exists(args.path_to_src_omop_dir):
@@ -608,6 +608,12 @@ def main():
             shutil.rmtree(args.path_to_dest_meds_dir)
     os.makedirs(args.path_to_dest_meds_dir, exist_ok=True)
 
+    if not args.omop_version:
+        omop_version = "5.4"
+    else:
+        omop_version = args.omop_version
+    if omop_version is not in ["5.4", "5.3"]
+        raise RuntimeError f"OMOP version {omop_version} not supported"
     # Within the target directory, create temporary subfolder for holding files
     # that need to be decompressed as part of the ETL (via eg `load_file`)
     path_to_decompressed_dir = os.path.join(args.path_to_dest_meds_dir, "decompressed")
@@ -685,7 +691,7 @@ def main():
             "visit": [
                 {"fallback_concept_id": DEFAULT_VISIT_CONCEPT_ID, "file_suffix": "occurrence"},
                 {
-                    "concept_id_field": "discharged_to_concept_id",
+                    "concept_id_field": "discharged_to_concept_id" if omop_version == "5.4" else "discharge_to_concept_id",
                     "time_field_options": ["visit_end_datetime", "visit_end_date"],
                     "file_suffix": "occurrence",
                 },

--- a/src/meds_etl/omop.py
+++ b/src/meds_etl/omop.py
@@ -594,7 +594,7 @@ def main():
         "conversion to MEDS Unsorted but before converting from MEDS Unsorted to MEDS.",
     )
     parser.add_argument("--force_refresh", action="store_true", help="If set, this will overwrite all previous MEDS data in the output dir.")
-    parser.add_argument("--omop_version", type=string, help="Switch between OMOP 5.3/5.4, default 5.4.")
+    parser.add_argument("--omop_version", type=str, help="Switch between OMOP 5.3/5.4, default 5.4.")
     args = parser.parse_args()
 
     if not os.path.exists(args.path_to_src_omop_dir):
@@ -612,8 +612,8 @@ def main():
         omop_version = "5.4"
     else:
         omop_version = args.omop_version
-    if omop_version is not in ["5.4", "5.3"]
-        raise RuntimeError f"OMOP version {omop_version} not supported"
+    if omop_version not in ["5.4", "5.3"]:
+        raise RuntimeError(f"OMOP version {omop_version} not supported")
     # Within the target directory, create temporary subfolder for holding files
     # that need to be decompressed as part of the ETL (via eg `load_file`)
     path_to_decompressed_dir = os.path.join(args.path_to_dest_meds_dir, "decompressed")


### PR DESCRIPTION
Now works with the MIMIC OMOP demo, due to the one column name change, which is in OMOP 5.3 (https://physionet.org/content/mimic-iv-demo-omop/0.9/).